### PR TITLE
Blink on update

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,5 +50,7 @@ This project is licensed under the MIT License - see the LICENSE.md file for det
 
 ## Resources
 
-* [Kasa API](https://github.com/python-kasa/python-kasa)
+* [Kasa API Library](https://github.com/python-kasa/python-kasa)
 * [Kasa API Docs](https://python-kasa.readthedocs.io/en/latest/smartdevice.html)
+* [OpenWeather API Library](https://github.com/csparpa/pyowm)
+* [OpenWeather API Docs](https://openweathermap.org/api)

--- a/lib/bulb.py
+++ b/lib/bulb.py
@@ -1,5 +1,6 @@
 from kasa import SmartBulb
 from lib.reporter import Reporter
+import time
 
 class Bulb(SmartBulb):
     async def report(self):
@@ -34,4 +35,9 @@ class Bulb(SmartBulb):
             hue = 0
 
         await self.update()
+        await self.blink(hue, saturation)
         await self.set_hsv(hue, saturation, value)
+
+    async def blink(self, hue, saturation):
+        await self.set_hsv(hue, saturation, 0, transition=1000)
+        time.sleep(1)


### PR DESCRIPTION
When we query the weather API, give the user some feedback through the bulb that
the service is still up and working. At each `INTERVAL_SECONDS` value, we'll
blink the bulb.

We may also in the future have an update blink interval when we know the score
will change, based on the forecast.